### PR TITLE
Load before tconstruct so events can be handled on default materials.…

### DIFF
--- a/src/main/java/slimeknights/harvesttweaks/HarvestTweaks.java
+++ b/src/main/java/slimeknights/harvesttweaks/HarvestTweaks.java
@@ -29,7 +29,8 @@ import slimeknights.mantle.pulsar.pulse.PulseMeta;
 @Mod(modid = HarvestTweaks.MODID,
     version = HarvestTweaks.VERSION,
     dependencies = "required-after:forge@[14.21.1.2410,);" +
-                   "required-after:mantle@[1.12-1.3.1,);",
+                   "required-after:mantle@[1.12-1.3.1,);" +
+                   "before:tconstruct;",
     acceptedMinecraftVersions = "[1.12, 1.13)"
 //    guiFactory = "slimeknights.harvesttweaks.config.ConfigGui$GuiFactory"
 )


### PR DESCRIPTION
… Fixes #16 
MaterialEvent.StatRegisterEvent for default mod materials is triggered before the mod loads.